### PR TITLE
Adapt the ros_example from Indigo/Gazebo2 to Melodic/Gazebo9, Change linear solver from customized library to public library

### DIFF
--- a/examples/ros_example/readme.md
+++ b/examples/ros_example/readme.md
@@ -1,10 +1,24 @@
 # ROS integration example
 ## Prerequisites
-This example assumes that you have a working ROS and Gazebo installed. While creating this example we used ROS Indigo and Gazebo 2. Make sure you have the ROS packages *ros-control* and *ros-controllers*:
+This example has updated to compatible with ROS melodic and Gazebo9. If you still using ROS Indogo and Gazebo2, you have to reset the commit back to https://github.com/meco-group/omg-tools/commit/beb4d3c78d2fb269671fde783b234d727b9c1fa1, because there are differences in xacro programming style between two versions. Please also check the previous README for usage if you reset the commit.
 
+
+Make sure you have the ROS packages *ros-control* and *ros-controllers*:
 ```
-$ sudo apt-get install ros-indigo-ros-control ros-indigo-ros-controllers
+$ sudo apt install ros-melodic-ros-control ros-melodic-ros-controllers
 ```
+For motion planner algorithm, recommended linear solver library is 'ma57', but this library is not available through 'apt' or 'pip', you have to compile it yourself, Please check https://github.com/casadi/casadi/wiki/Obtaining-HSL if you are interest. To check whether 'ma57' is available in your computer, you can run:
+```
+python /examples/p2p_agv.py
+```
+to see if it complains about the 'ma57' library missing.
+
+
+The substitution of 'ma57' is 'mumps', this changes already adressed here. 'mumps' is available through 'apt'
+```
+sudo apt install libmumps-dev
+```
+If you have 'ma57' library in your computer, go to line 77 and 82 in 'motionplanner.py', change the 'mumps' to 'ma57' to make palnner running faster.
 
 ## Building the example
 In the current folder (the one containing this readme):
@@ -17,7 +31,11 @@ $ source devel/setup.bash
 ## Running the example
 
 ```
-$ roscore &
-$ roslaunch p3dx_gazebo gazebo.launch &
+$ roscore 
+```
+```
+$ roslaunch p3dx_gazebo gazebo.launch 
+```
+```
 $ roslaunch p3dx_motionplanner motionplanner.launch
 ```

--- a/examples/ros_example/src/CMakeLists.txt
+++ b/examples/ros_example/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/kinetic/share/catkin/cmake/toplevel.cmake
+/opt/ros/melodic/share/catkin/cmake/toplevel.cmake

--- a/examples/ros_example/src/p3dx_description/urdf/pioneer3dx.gazebo
+++ b/examples/ros_example/src/p3dx_description/urdf/pioneer3dx.gazebo
@@ -18,10 +18,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
  -->
 
-<robot>
+<robot name="pioneer3dx" xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- properties (constants) -->
-  <property name="ns" value="p3dx" />
+  <xacro:property name="ns" value="p3dx" />
 
   <!-- ros_control plugin -->
   <gazebo>
@@ -69,8 +69,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 		<plugin name="differential_drive_controller" filename="libgazebo_ros_diff_drive.so">
 			<alwaysOn>true</alwaysOn>
 			<updateRate>100</updateRate>
-			<leftJoint>base_right_wheel_joint</leftJoint>
-			<rightJoint>base_left_wheel_joint</rightJoint>
+			<leftJoint>base_left_wheel_joint</leftJoint>
+			<rightJoint>base_right_wheel_joint</rightJoint>
             <!-- <wheelSeparation>0.39</wheelSeparation> -->
 			<wheelSeparation>0.316</wheelSeparation>
             <!-- <wheelDiameter>0.15</wheelDiameter> -->
@@ -82,7 +82,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 			<odometryFrame>odom</odometryFrame>
 			<robotBaseFrame>base_link</robotBaseFrame>
 
-            <legacyMode>true</legacyMode>
+
 		</plugin>
 	</gazebo>
 

--- a/examples/ros_example/src/p3dx_description/urdf/pioneer3dx.xacro
+++ b/examples/ros_example/src/p3dx_description/urdf/pioneer3dx.xacro
@@ -37,7 +37,7 @@ work original in ucs-ros-pkg.
 			<inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1" />
 		</inertial>
 
-		<visual name="base_visual">
+		<visual>
 			<origin xyz="-0.045 0 0.148" rpy="0 0 0" />
 			<geometry name="pioneer_geom">
 				<mesh filename="package://p3dx_description/meshes/chassis.stl" />
@@ -63,7 +63,7 @@ work original in ucs-ros-pkg.
 			<inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1" />
 		</inertial>
 
-		<visual name="base_visual">
+		<visual>
 			<origin xyz="0 0 0" rpy="0 0 0" />
 			<geometry name="top_geom">
 				<mesh filename="package://p3dx_description/meshes/top.stl" />
@@ -96,7 +96,7 @@ work original in ucs-ros-pkg.
 			<inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01" />
 		</inertial>
 
-		<visual name="base_visual">
+		<visual>
 			<origin xyz="0 0 0" rpy="0 0 0" />
 			<geometry name="pioneer_geom">
 				<mesh filename="package://p3dx_description/meshes/swivel.stl" />
@@ -134,7 +134,7 @@ work original in ucs-ros-pkg.
 				iyy="0.015218160428" iyz="-0.000004273467" izz="0.011763977943" />
 		</inertial>
 
-		<visual name="base_visual">
+		<visual>
 			<origin xyz="0 0 0" rpy="0 0 0" />
 			<geometry name="pioneer_geom">
 				<mesh filename="package://p3dx_description/meshes/center_hubcap.stl" />
@@ -172,7 +172,7 @@ work original in ucs-ros-pkg.
 				iyy="0.015218160428" iyz="-0.000004273467" izz="0.011763977943" />
 		</inertial>
 
-		<visual name="base_visual">
+		<visual>
 			<origin xyz="0 0 0" rpy="0 0 0" />
 			<geometry name="pioneer_geom">
 				<mesh filename="package://p3dx_description/meshes/center_wheel.stl" />
@@ -207,7 +207,7 @@ work original in ucs-ros-pkg.
 			<inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1" />
 		</inertial>
 
-		<visual name="front_sonar_vis">
+		<visual>
 			<origin rpy="0 0 0" xyz="0 0 0" />
 			<geometry name="pioneer_geom">
 				<mesh filename="package://p3dx_description/meshes/front_sonar.stl" />

--- a/examples/ros_example/src/p3dx_description/urdf/pioneer3dx_wheel.xacro
+++ b/examples/ros_example/src/p3dx_description/urdf/pioneer3dx_wheel.xacro
@@ -24,7 +24,7 @@ work original in ucs-ros-pkg.
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
 	<!-- properties (constants) -->
-	<property name="M_PI" value="3.14159" />
+	<xacro:property name="M_PI" value="3.14159" />
 
 	<!-- right/left hubcap + wheel -->
 	<xacro:macro name="p3dx_wheel" params="suffix parent reflect">
@@ -38,7 +38,7 @@ work original in ucs-ros-pkg.
 					iyz="0" izz="0.011763977943" />
 			</inertial>
 
-			<visual name="base_visual">
+			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0" />
 				<geometry name="pioneer_geom">
 					<mesh filename="package://p3dx_description/meshes/${suffix}_wheel.stl" />
@@ -72,7 +72,7 @@ work original in ucs-ros-pkg.
 					iyz="0" izz="0.011763977943" />
 			</inertial>
 
-			<visual name="base_visual">
+			<visual>
 				<origin xyz="0 0 0" rpy="0 0 0" />
 				<geometry name="pioneer_geom">
 					<mesh filename="package://p3dx_description/meshes/${suffix}_hubcap.stl" />

--- a/examples/ros_example/src/p3dx_gazebo/launch/gazebo.launch
+++ b/examples/ros_example/src/p3dx_gazebo/launch/gazebo.launch
@@ -23,7 +23,7 @@
 		a URDF robot -->
 
 	<param name="robot_description"
-        command="$(find xacro)/xacro.py '$(find p3dx_description)/urdf/pioneer3dx.xacro'" />
+        command="$(find xacro)/xacro '$(find p3dx_description)/urdf/pioneer3dx.xacro'" />
 
 
 	<group ns="robot0">

--- a/examples/ros_example/src/p3dx_gazebo/launch/one_robot.launch
+++ b/examples/ros_example/src/p3dx_gazebo/launch/one_robot.launch
@@ -1,9 +1,8 @@
 <launch>
     <arg name="robot_name"/>
     <arg name="init_pose"/>
-    <param name="robot_description"
-        command="$(find xacro)/xacro.py '$(find p3dx_description)/urdf/pioneer3dx.xacro'" />
+
     <node name="spawn_robot" pkg="gazebo_ros" type="spawn_model"
-        args="$(arg init_pose) -urdf -param robot_description -model $(arg robot_name)"
+        args="$(arg init_pose) -urdf -param /robot_description -model $(arg robot_name)"
         respawn="false" output="screen" />
 </launch>

--- a/examples/ros_example/src/p3dx_motionplanner/src/motionplanner.py
+++ b/examples/ros_example/src/p3dx_motionplanner/src/motionplanner.py
@@ -74,12 +74,12 @@ class MotionPlanner(object):
         print('creating problem')
         if self._n_robots == 1:
             problem = omg.Point2point(self._fleet, environment, freeT=False)
-            problem.set_options({'solver_options': {'ipopt': {'ipopt.linear_solver': 'ma57', 'ipopt.hessian_approximation': 'limited-memory'}}})
+            problem.set_options({'solver_options': {'ipopt': {'ipopt.linear_solver': 'mumps', 'ipopt.hessian_approximation': 'limited-memory'}}})
             problem.set_options({'hard_term_con': False, 'horizon_time': 10.})
         else:
             options = {'rho': 5., 'horizon_time': 35., 'hard_term_con': True, 'init_iter':5}
             problem = omg.FormationPoint2point(self._fleet, environment, options=options)
-            problem.set_options({'solver_options': {'ipopt': {'ipopt.linear_solver': 'ma57', 'ipopt.max_iter': 500}}})
+            problem.set_options({'solver_options': {'ipopt': {'ipopt.linear_solver': 'mumps', 'ipopt.max_iter': 500}}})
         problem.init()
         self._deployer = omg.Deployer(problem, self._sample_time, self._update_time)
         self._deployer.reset()


### PR DESCRIPTION
Original xacro files has color visualization problem in Melodic/Gazebo9, and there are also deprecated warnings.  

In Melodic, there is no 'LegacyMode' for 'differential_driver_controller' anymore, so no need switch left and right anymore. Otherwise you will see robots rotate opposite way around in Gazebo.

'ma57' linear solver is not a public library available through 'apt' and 'pip', change it to public solver 'mumps' in ros_example source python code.